### PR TITLE
[ClickAndLoad] fix bug when package name contains non ascii characters

### DIFF
--- a/pyload/api/__init__.py
+++ b/pyload/api/__init__.py
@@ -336,7 +336,7 @@ class Api(Iface):
 
         self.core.files.addLinks(links, pid)
 
-        self.core.log.info(_("Added package %(name)s containing %(count)d links") % {"name": name, "count": len(links)})
+        self.core.log.info(_("Added package %(name)s containing %(count)d links") % {"name": name.decode('utf-8'), "count": len(links)})
 
         self.core.files.save()
 


### PR DESCRIPTION
fix #1199
